### PR TITLE
Fixed replica set creation for transaction support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,10 +81,10 @@
 				<version>${assertj-swing.version}</version>
 				<scope>test</scope>
 			</dependency>
-			<!-- https://mvnrepository.com/artifact/org.testcontainers/testcontainers -->
+			<!-- https://mvnrepository.com/artifact/org.testcontainers/mongodb -->
 			<dependency>
 				<groupId>org.testcontainers</groupId>
-				<artifactId>testcontainers</artifactId>
+				<artifactId>mongodb</artifactId>
 				<version>${testcontainers.version}</version>
 				<scope>test</scope>
 			</dependency>
@@ -105,42 +105,40 @@
 	</dependencyManagement>
 
 	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.pitest</groupId>
-				<artifactId>pitest-maven</artifactId>
-				<version>${pitest.version}</version>
-				<configuration>
-					<excludedClasses>
-						<param>*Test</param>
-						<param>*IT</param>
-						<param>it.unifi.simpletodoapp.TodoApplication</param>
-						<param>it.unifi.simpletodoapp.model.*</param>
-						<param>it.unifi.simpletodoapp.view.*</param>
-						<!-- Removed since there are no unit tests for this class (only IT 
-							are possible) -->
-						<param>it.unifi.simpletodoapp.repository.mongo.TransactionManagerMongo</param>
-					</excludedClasses>
-					<targetModules>
-						<param>simpletodoapp-base</param>
-						<param>simpletodoapp-gui</param>
-					</targetModules>
-					<targetTests>
-						<param>it.unifi.simpletodoapp.*Test</param>
-					</targetTests>
-					<excludedTestClasses>
-						<!-- Excluding UI tests since it can't use xvfb and always fails -->
-						<param>it.unifi.simpletodoapp.view.swing.TodoSwingViewTest</param>
-					</excludedTestClasses>
-					<mutators>
-						<mutator>STRONGER</mutator>
-					</mutators>
-					<mutationThreshold>100</mutationThreshold>
-				</configuration>
-			</plugin>
-		</plugins>
 		<pluginManagement>
 			<plugins>
+				<plugin>
+					<groupId>org.pitest</groupId>
+					<artifactId>pitest-maven</artifactId>
+					<version>${pitest.version}</version>
+					<configuration>
+						<excludedClasses>
+							<param>*Test</param>
+							<param>*IT</param>
+							<param>it.unifi.simpletodoapp.TodoApplication</param>
+							<param>it.unifi.simpletodoapp.model.*</param>
+							<param>it.unifi.simpletodoapp.view.*</param>
+							<!-- Removed since there are no unit tests for this class (only IT 
+								are possible) -->
+							<param>it.unifi.simpletodoapp.repository.mongo.TransactionManagerMongo</param>
+						</excludedClasses>
+						<targetModules>
+							<param>simpletodoapp-base</param>
+							<param>simpletodoapp-gui</param>
+						</targetModules>
+						<targetTests>
+							<param>it.unifi.simpletodoapp.*Test</param>
+						</targetTests>
+						<excludedTestClasses>
+							<!-- Excluding UI tests since it can't use xvfb and always fails -->
+							<param>it.unifi.simpletodoapp.view.swing.TodoSwingViewTest</param>
+						</excludedTestClasses>
+						<mutators>
+							<mutator>STRONGER</mutator>
+						</mutators>
+						<mutationThreshold>100</mutationThreshold>
+					</configuration>
+				</plugin>
 				<plugin>
 					<groupId>org.sonarsource.scanner.maven</groupId>
 					<artifactId>sonar-maven-plugin</artifactId>

--- a/settings.xml
+++ b/settings.xml
@@ -19,13 +19,13 @@
 
 				<!-- Remove the coverage of classes from Sonar -->
 				<sonar.coverage.exclusions>
-					**/model/*.*,
-					**/TransactionManagerMongo.*
+					**/model/*.*
 				</sonar.coverage.exclusions>
 
 				<sonar.issue.ignore.multicriteria>
 					e1,e2,e3
 				</sonar.issue.ignore.multicriteria>
+				
 				<!-- Ignore "Inheritance tree of classes should not be too deep": the 
 					Swing view must extend JFrame (with 4 parents) and implement the view interface -->
 				<sonar.issue.ignore.multicriteria.e1.ruleKey>
@@ -34,6 +34,7 @@
 				<sonar.issue.ignore.multicriteria.e1.resourceKey>
 					**/TodoSwingView.*
 				</sonar.issue.ignore.multicriteria.e1.resourceKey>
+				
 				<!-- Ignore "Tests should include assertions": assertions are made using 
 					AssertJ Swing -->
 				<sonar.issue.ignore.multicriteria.e2.ruleKey>
@@ -42,6 +43,7 @@
 				<sonar.issue.ignore.multicriteria.e2.resourceKey>
 					**/TodoSwingViewTest.*
 				</sonar.issue.ignore.multicriteria.e2.resourceKey>
+				
 				<!-- Ignore "equals(Object obj) and hashCode() should be overridden in 
 					pairs": the view model classes do not need such method, we're only interested 
 					in a trivial equality operator -->

--- a/simpletodoapp-base/.classpath
+++ b/simpletodoapp-base/.classpath
@@ -37,5 +37,10 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/simpletodoapp-base/pom.xml
+++ b/simpletodoapp-base/pom.xml
@@ -42,11 +42,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>testcontainers</artifactId>
+			<artifactId>mongodb</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	
+
 	<build>
 		<plugins>
 			<plugin>

--- a/simpletodoapp-base/src/it/java/it/unifi/simpletodoapp/repository/mongo/TagMongoRepositoryIT.java
+++ b/simpletodoapp-base/src/it/java/it/unifi/simpletodoapp/repository/mongo/TagMongoRepositoryIT.java
@@ -14,10 +14,10 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MongoDBContainer;
 
-import com.mongodb.MongoClient;
-import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
@@ -30,10 +30,9 @@ public class TagMongoRepositoryIT {
 	private static final String DB_NAME = "todoapp";
 	private static final String TAGS_COLLECTION = "tags";
 
-	@SuppressWarnings("rawtypes")
 	@ClassRule
-	public static final GenericContainer mongoContainer =
-	new GenericContainer("krnbr/mongo").withExposedPorts(MONGO_PORT);
+	public static final MongoDBContainer mongoContainer = new MongoDBContainer()
+	.withExposedPorts(MONGO_PORT);
 
 	private MongoClient mongoClient;
 	private ClientSession clientSession;
@@ -44,11 +43,10 @@ public class TagMongoRepositoryIT {
 	public void setup() {
 		/* Creates the mongo client by connecting it to the mongodb instance, the tag
 		 * repository and collection; also empties the database before each test */
-		mongoClient = new MongoClient(new ServerAddress(
-				mongoContainer.getContainerIpAddress(),
-				mongoContainer.getMappedPort(MONGO_PORT)
-				));
+		String mongoRsUrl = mongoContainer.getReplicaSetUrl();
+		mongoClient = MongoClients.create(mongoRsUrl);
 		clientSession = mongoClient.startSession();
+		
 		tagMongoRepository = new TagMongoRepository(mongoClient, DB_NAME, TAGS_COLLECTION);
 
 		MongoDatabase database = mongoClient.getDatabase(DB_NAME);

--- a/simpletodoapp-base/src/it/java/it/unifi/simpletodoapp/repository/mongo/TagMongoRepositoryIT.java
+++ b/simpletodoapp-base/src/it/java/it/unifi/simpletodoapp/repository/mongo/TagMongoRepositoryIT.java
@@ -12,8 +12,10 @@ import org.bson.Document;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.MongoDBContainer;
 
 import com.mongodb.client.MongoClient;
@@ -23,6 +25,9 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 import it.unifi.simpletodoapp.model.Tag;
 
 public class TagMongoRepositoryIT {
@@ -38,6 +43,13 @@ public class TagMongoRepositoryIT {
 	private ClientSession clientSession;
 	private TagMongoRepository tagMongoRepository;
 	private MongoCollection<Document> tagCollection;
+	
+	@BeforeClass
+	public static void setupMongoLogger() {
+		LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+		Logger rootLogger = loggerContext.getLogger("org.mongodb.driver");
+		rootLogger.setLevel(Level.INFO);
+	}
 
 	@Before
 	public void setup() {

--- a/simpletodoapp-base/src/it/java/it/unifi/simpletodoapp/repository/mongo/TaskMongoRepositoryIT.java
+++ b/simpletodoapp-base/src/it/java/it/unifi/simpletodoapp/repository/mongo/TaskMongoRepositoryIT.java
@@ -14,11 +14,11 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MongoDBContainer;
 
-import com.mongodb.MongoClient;
-import com.mongodb.ServerAddress;
 import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
@@ -30,10 +30,9 @@ public class TaskMongoRepositoryIT {
 	private static final String DB_NAME = "todoapp";
 	private static final String TASKS_COLLECTION = "tasks";
 
-	@SuppressWarnings("rawtypes")
 	@ClassRule
-	public static final GenericContainer mongoContainer =
-	new GenericContainer("krnbr/mongo").withExposedPorts(MONGO_PORT);
+	public static final MongoDBContainer mongoContainer = new MongoDBContainer()
+	.withExposedPorts(MONGO_PORT);
 
 	private MongoClient mongoClient;
 	private ClientSession clientSession;
@@ -44,11 +43,10 @@ public class TaskMongoRepositoryIT {
 	public void setup() {
 		/* Creates the mongo client by connecting it to the mongodb instance, the task
 		 * repository and collection; also empties the database before each test */
-		mongoClient = new MongoClient(new ServerAddress(
-				mongoContainer.getContainerIpAddress(),
-				mongoContainer.getMappedPort(MONGO_PORT)
-				));
+		String mongoRsUrl = mongoContainer.getReplicaSetUrl();
+		mongoClient = MongoClients.create(mongoRsUrl);
 		clientSession = mongoClient.startSession();
+		
 		taskMongoRepository = new TaskMongoRepository(mongoClient, DB_NAME, TASKS_COLLECTION);
 
 		MongoDatabase database = mongoClient.getDatabase(DB_NAME);

--- a/simpletodoapp-base/src/it/java/it/unifi/simpletodoapp/repository/mongo/TaskMongoRepositoryIT.java
+++ b/simpletodoapp-base/src/it/java/it/unifi/simpletodoapp/repository/mongo/TaskMongoRepositoryIT.java
@@ -12,8 +12,10 @@ import org.bson.Document;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.MongoDBContainer;
 
 import com.mongodb.client.ClientSession;
@@ -23,6 +25,9 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 import it.unifi.simpletodoapp.model.Task;
 
 public class TaskMongoRepositoryIT {
@@ -38,6 +43,13 @@ public class TaskMongoRepositoryIT {
 	private ClientSession clientSession;
 	private TaskMongoRepository taskMongoRepository;
 	private MongoCollection<Document> taskCollection;
+	
+	@BeforeClass
+	public static void setupMongoLogger() {
+		LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+		Logger rootLogger = loggerContext.getLogger("org.mongodb.driver");
+		rootLogger.setLevel(Level.INFO);
+	}
 
 	@Before
 	public void setup() {

--- a/simpletodoapp-base/src/it/java/it/unifi/simpletodoapp/repository/mongo/TransactionManagerMongoIT.java
+++ b/simpletodoapp-base/src/it/java/it/unifi/simpletodoapp/repository/mongo/TransactionManagerMongoIT.java
@@ -11,8 +11,10 @@ import org.bson.Document;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.MongoDBContainer;
 
 import com.mongodb.MongoException;
@@ -22,6 +24,9 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 import it.unifi.simpletodoapp.model.Tag;
 import it.unifi.simpletodoapp.model.Task;
 
@@ -43,6 +48,13 @@ public class TransactionManagerMongoIT {
 	private TagMongoRepository tagMongoRepository;
 	private MongoCollection<Document> taskCollection;
 	private MongoCollection<Document> tagCollection;
+	
+	@BeforeClass
+	public static void setupMongoLogger() {
+		LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+		Logger rootLogger = loggerContext.getLogger("org.mongodb.driver");
+		rootLogger.setLevel(Level.INFO);
+	}
 
 	@Before
 	public void setup() {

--- a/simpletodoapp-base/src/it/java/it/unifi/simpletodoapp/repository/mongo/TransactionManagerMongoIT.java
+++ b/simpletodoapp-base/src/it/java/it/unifi/simpletodoapp/repository/mongo/TransactionManagerMongoIT.java
@@ -13,12 +13,11 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MongoDBContainer;
 
-import com.mongodb.MongoClient;
 import com.mongodb.MongoException;
-import com.mongodb.ServerAddress;
-import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
@@ -32,15 +31,14 @@ public class TransactionManagerMongoIT {
 	private static final String TASKS_COLLECTION = "tasks";
 	private static final String TAGS_COLLECTION = "tags";
 
-	@SuppressWarnings("rawtypes")
 	@ClassRule
-	public static final GenericContainer mongoContainer =
-	new GenericContainer("krnbr/mongo").withExposedPorts(MONGO_PORT);
+	public static final MongoDBContainer mongoContainer = new MongoDBContainer()
+	.withExposedPorts(MONGO_PORT);
 
 	private TransactionManagerMongo transactionManagerMongo;
 
 	private MongoClient mongoClient;
-	private ClientSession clientSession;
+	private MongoDatabase mongoDatabase;
 	private TaskMongoRepository taskMongoRepository;
 	private TagMongoRepository tagMongoRepository;
 	private MongoCollection<Document> taskCollection;
@@ -51,33 +49,29 @@ public class TransactionManagerMongoIT {
 		/* Creates the mongo client by connecting it to the mongodb instance, both
 		 * repositories and collections and the transaction manager; also empties
 		 * the database before each test */
-		mongoClient = new MongoClient(new ServerAddress(
-				mongoContainer.getContainerIpAddress(),
-				mongoContainer.getMappedPort(MONGO_PORT))
-				);
-		clientSession = mongoClient.startSession();
+		String mongoRsUrl = mongoContainer.getReplicaSetUrl();
+		mongoClient = MongoClients.create(mongoRsUrl);
+
 		taskMongoRepository = new TaskMongoRepository(mongoClient, DB_NAME, TASKS_COLLECTION);
 		tagMongoRepository = new TagMongoRepository(mongoClient, DB_NAME, TAGS_COLLECTION);
 
 		transactionManagerMongo = new TransactionManagerMongo(mongoClient, taskMongoRepository, tagMongoRepository);
 
-		MongoDatabase database = mongoClient.getDatabase(DB_NAME);
+		mongoDatabase = mongoClient.getDatabase(DB_NAME);
 
-		database.drop();
-		database.createCollection(TASKS_COLLECTION);
-		database.createCollection(TAGS_COLLECTION);
-		taskCollection = database.getCollection(TASKS_COLLECTION);
-		tagCollection = database.getCollection(TAGS_COLLECTION);
+		mongoDatabase.drop();
+		mongoDatabase.createCollection(TASKS_COLLECTION);
+		mongoDatabase.createCollection(TAGS_COLLECTION);
+		taskCollection = mongoDatabase.getCollection(TASKS_COLLECTION);
+		tagCollection = mongoDatabase.getCollection(TAGS_COLLECTION);
 	}
-
+	
 	@After
 	public void tearDown() {
 		/* Close the client connection after each test so that it can
 		 * be created anew in the next test */
-		clientSession.close();
 		mongoClient.close();
 	}
-
 
 	@AfterClass
 	public static void stopContainer() {
@@ -105,7 +99,7 @@ public class TransactionManagerMongoIT {
 	@Test
 	public void testTaskTransactionAborted() {
 		// Setup phase
-		mongoClient.getDatabase(DB_NAME).drop();
+		mongoDatabase.drop();
 		Task task = new Task("1", "Start using TDD");
 
 		// Exercise and verify phases
@@ -139,7 +133,7 @@ public class TransactionManagerMongoIT {
 	@Test
 	public void testTagTransactionAborted() {
 		// Setup phase
-		mongoClient.getDatabase(DB_NAME).drop();
+		mongoDatabase.drop();
 		Tag tag = new Tag("1", "Work");
 
 		// Exercise and verify phases
@@ -180,7 +174,7 @@ public class TransactionManagerMongoIT {
 	@Test
 	public void testCompositeTransactionAborted() {
 		// Setup phase
-		mongoClient.getDatabase(DB_NAME).drop();
+		mongoDatabase.drop();
 		Task task = new Task("1", "Start using TDD");
 		Tag tag = new Tag("1", "Work");
 

--- a/simpletodoapp-base/src/it/java/it/unifi/simpletodoapp/service/TodoServiceTransactionsIT.java
+++ b/simpletodoapp-base/src/it/java/it/unifi/simpletodoapp/service/TodoServiceTransactionsIT.java
@@ -13,10 +13,10 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MongoDBContainer;
 
-import com.mongodb.MongoClient;
-import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
@@ -33,10 +33,9 @@ public class TodoServiceTransactionsIT {
 	private static final String TASKS_COLLECTION = "tasks";
 	private static final String TAGS_COLLECTION = "tags";
 
-	@SuppressWarnings("rawtypes")
 	@ClassRule
-	public static final GenericContainer mongoContainer =
-	new GenericContainer("krnbr/mongo").withExposedPorts(MONGO_PORT);
+	public static final MongoDBContainer mongoContainer = new MongoDBContainer()
+	.withExposedPorts(MONGO_PORT);
 	
 	private TodoService todoService;
 	private TransactionManagerMongo transactionManagerMongo;
@@ -53,10 +52,9 @@ public class TodoServiceTransactionsIT {
 		/* Creates the mongo client by connecting it to the mongodb instance, both
 		 * repositories and collections and the transaction manager; also empties
 		 * the database before each test */
-		mongoClient = new MongoClient(new ServerAddress(
-				mongoContainer.getContainerIpAddress(),
-				mongoContainer.getMappedPort(MONGO_PORT))
-				);
+		String mongoRsUrl = mongoContainer.getReplicaSetUrl();
+		mongoClient = MongoClients.create(mongoRsUrl);
+		
 		taskMongoRepository = new TaskMongoRepository(mongoClient, DB_NAME, TASKS_COLLECTION);
 		tagMongoRepository = new TagMongoRepository(mongoClient, DB_NAME, TAGS_COLLECTION);
 		transactionManagerMongo = new TransactionManagerMongo(mongoClient, taskMongoRepository, tagMongoRepository);

--- a/simpletodoapp-base/src/it/java/it/unifi/simpletodoapp/service/TodoServiceTransactionsIT.java
+++ b/simpletodoapp-base/src/it/java/it/unifi/simpletodoapp/service/TodoServiceTransactionsIT.java
@@ -11,8 +11,10 @@ import org.bson.Document;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.MongoDBContainer;
 
 import com.mongodb.client.MongoClient;
@@ -21,6 +23,9 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 import it.unifi.simpletodoapp.model.Tag;
 import it.unifi.simpletodoapp.model.Task;
 import it.unifi.simpletodoapp.repository.mongo.TagMongoRepository;
@@ -46,6 +51,13 @@ public class TodoServiceTransactionsIT {
 	
 	private MongoCollection<Document> taskCollection;
 	private MongoCollection<Document> tagCollection;
+	
+	@BeforeClass
+	public static void setupMongoLogger() {
+		LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+		Logger rootLogger = loggerContext.getLogger("org.mongodb.driver");
+		rootLogger.setLevel(Level.INFO);
+	}
 	
 	@Before
 	public void setup() {

--- a/simpletodoapp-base/src/main/java/it/unifi/simpletodoapp/repository/mongo/TagMongoRepository.java
+++ b/simpletodoapp-base/src/main/java/it/unifi/simpletodoapp/repository/mongo/TagMongoRepository.java
@@ -7,7 +7,7 @@ import java.util.stream.StreamSupport;
 
 import org.bson.Document;
 
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;

--- a/simpletodoapp-base/src/main/java/it/unifi/simpletodoapp/repository/mongo/TaskMongoRepository.java
+++ b/simpletodoapp-base/src/main/java/it/unifi/simpletodoapp/repository/mongo/TaskMongoRepository.java
@@ -7,7 +7,7 @@ import java.util.stream.StreamSupport;
 
 import org.bson.Document;
 
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;

--- a/simpletodoapp-base/src/main/java/it/unifi/simpletodoapp/repository/mongo/TransactionManagerMongo.java
+++ b/simpletodoapp-base/src/main/java/it/unifi/simpletodoapp/repository/mongo/TransactionManagerMongo.java
@@ -1,6 +1,6 @@
 package it.unifi.simpletodoapp.repository.mongo;
 
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 import com.mongodb.MongoException;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.TransactionBody;

--- a/simpletodoapp-base/src/main/resources/logback-test.xml
+++ b/simpletodoapp-base/src/main/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="com.github.dockerjava" level="INFO"/>
+</configuration>

--- a/simpletodoapp-base/src/test/java/it/unifi/simpletodoapp/repository/mongo/TagMongoRepositoryTest.java
+++ b/simpletodoapp-base/src/test/java/it/unifi/simpletodoapp/repository/mongo/TagMongoRepositoryTest.java
@@ -11,8 +11,10 @@ import org.bson.Document;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.MongoDBContainer;
 
 import com.mongodb.client.ClientSession;
@@ -21,6 +23,9 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 import it.unifi.simpletodoapp.model.Tag;
 
 public class TagMongoRepositoryTest {
@@ -36,6 +41,13 @@ public class TagMongoRepositoryTest {
 	@ClassRule
 	public static final MongoDBContainer mongoContainer = new MongoDBContainer()
 	.withExposedPorts(MONGO_PORT);
+	
+	@BeforeClass
+	public static void setupMongoLogger() {
+		LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+		Logger rootLogger = loggerContext.getLogger("org.mongodb.driver");
+		rootLogger.setLevel(Level.INFO);
+	}
 
 	@Before
 	public void setup() {

--- a/simpletodoapp-base/src/test/java/it/unifi/simpletodoapp/repository/mongo/TagMongoRepositoryTest.java
+++ b/simpletodoapp-base/src/test/java/it/unifi/simpletodoapp/repository/mongo/TagMongoRepositoryTest.java
@@ -13,11 +13,11 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MongoDBContainer;
 
-import com.mongodb.MongoClient;
-import com.mongodb.ServerAddress;
 import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
@@ -33,20 +33,18 @@ public class TagMongoRepositoryTest {
 	private TagMongoRepository tagMongoRepository;
 	private MongoCollection<Document> tagCollection;
 
-	@SuppressWarnings("rawtypes")
 	@ClassRule
-	public static final GenericContainer mongoContainer =
-	new GenericContainer("krnbr/mongo").withExposedPorts(MONGO_PORT);
+	public static final MongoDBContainer mongoContainer = new MongoDBContainer()
+	.withExposedPorts(MONGO_PORT);
 
 	@Before
 	public void setup() {
 		/* Creates the mongo client by connecting it to the mongodb instance, the tag
 		 * repository and collection; also empties the database before each test */
-		mongoClient = new MongoClient(new ServerAddress(
-				mongoContainer.getContainerIpAddress(),
-				mongoContainer.getMappedPort(MONGO_PORT)
-				));
+		String mongoRsUrl = mongoContainer.getReplicaSetUrl();
+		mongoClient = MongoClients.create(mongoRsUrl);
 		clientSession = mongoClient.startSession();
+		
 		tagMongoRepository = new TagMongoRepository(mongoClient, DB_NAME, DB_COLLECTION);
 
 		MongoDatabase database = mongoClient.getDatabase(DB_NAME);

--- a/simpletodoapp-base/src/test/java/it/unifi/simpletodoapp/repository/mongo/TaskMongoRepositoryTest.java
+++ b/simpletodoapp-base/src/test/java/it/unifi/simpletodoapp/repository/mongo/TaskMongoRepositoryTest.java
@@ -13,11 +13,11 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MongoDBContainer;
 
-import com.mongodb.MongoClient;
-import com.mongodb.ServerAddress;
 import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
@@ -33,20 +33,18 @@ public class TaskMongoRepositoryTest {
 	private TaskMongoRepository taskMongoRepository;
 	private MongoCollection<Document> taskCollection;
 
-	@SuppressWarnings("rawtypes")
 	@ClassRule
-	public static final GenericContainer mongoContainer =
-	new GenericContainer("krnbr/mongo").withExposedPorts(MONGO_PORT);
+	public static final MongoDBContainer mongoContainer = new MongoDBContainer()
+	.withExposedPorts(MONGO_PORT);
 
 	@Before
 	public void setup() {
 		/* Creates the mongo client by connecting it to the mongodb instance, the task
 		 * repository and collection; also empties the database before each test */
-		mongoClient = new MongoClient(new ServerAddress(
-				mongoContainer.getContainerIpAddress(),
-				mongoContainer.getMappedPort(MONGO_PORT))
-				);
+		String mongoRsUrl = mongoContainer.getReplicaSetUrl();
+		mongoClient = MongoClients.create(mongoRsUrl);
 		clientSession = mongoClient.startSession();
+		
 		taskMongoRepository = new TaskMongoRepository(mongoClient, DB_NAME, DB_COLLECTION);
 
 		MongoDatabase database = mongoClient.getDatabase(DB_NAME);

--- a/simpletodoapp-base/src/test/java/it/unifi/simpletodoapp/repository/mongo/TaskMongoRepositoryTest.java
+++ b/simpletodoapp-base/src/test/java/it/unifi/simpletodoapp/repository/mongo/TaskMongoRepositoryTest.java
@@ -11,8 +11,10 @@ import org.bson.Document;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.MongoDBContainer;
 
 import com.mongodb.client.ClientSession;
@@ -21,6 +23,9 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 import it.unifi.simpletodoapp.model.Task;
 
 public class TaskMongoRepositoryTest {
@@ -36,6 +41,13 @@ public class TaskMongoRepositoryTest {
 	@ClassRule
 	public static final MongoDBContainer mongoContainer = new MongoDBContainer()
 	.withExposedPorts(MONGO_PORT);
+	
+	@BeforeClass
+	public static void setupMongoLogger() {
+		LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+		Logger rootLogger = loggerContext.getLogger("org.mongodb.driver");
+		rootLogger.setLevel(Level.INFO);
+	}
 
 	@Before
 	public void setup() {

--- a/simpletodoapp-gui/pom.xml
+++ b/simpletodoapp-gui/pom.xml
@@ -46,7 +46,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>testcontainers</artifactId>
+			<artifactId>mongodb</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -55,7 +55,7 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	
+
 	<build>
 		<plugins>
 			<plugin>

--- a/simpletodoapp-gui/src/e2e/java/it/unifi/simpletodoapp/view/swing/app/TodoSwingAppE2E.java
+++ b/simpletodoapp-gui/src/e2e/java/it/unifi/simpletodoapp/view/swing/app/TodoSwingAppE2E.java
@@ -20,9 +20,12 @@ import org.assertj.swing.fixture.JTabbedPaneFixture;
 import org.assertj.swing.junit.runner.GUITestRunner;
 import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
 import org.bson.Document;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.MongoDBContainer;
 
 import com.mongodb.client.MongoClient;
@@ -30,6 +33,9 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Updates;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 import it.unifi.simpletodoapp.model.Tag;
 import it.unifi.simpletodoapp.model.Task;
 
@@ -123,6 +129,19 @@ public class TodoSwingAppE2E extends AssertJSwingJUnitTestCase {
 		/* Close the client connection after each test so that it can
 		 * be created anew in the next test */
 		mongoClient.close();
+	}
+	
+	@BeforeClass
+	public static void setupMongoLogger() {
+		LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+		Logger rootLogger = loggerContext.getLogger("org.mongodb.driver");
+		rootLogger.setLevel(Level.INFO);
+	}
+	
+	@AfterClass
+	public static void stopContainer() {
+		// Stops the container after all methods have been executed
+		mongoContainer.stop();
 	}
 
 	@Test @GUITest

--- a/simpletodoapp-gui/src/it/java/it/unifi/simpletodoapp/controller/TodoControllerServiceIT.java
+++ b/simpletodoapp-gui/src/it/java/it/unifi/simpletodoapp/controller/TodoControllerServiceIT.java
@@ -12,10 +12,12 @@ import org.bson.Document;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.MongoDBContainer;
 
 import com.mongodb.client.MongoClient;
@@ -24,6 +26,9 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 import it.unifi.simpletodoapp.model.Tag;
 import it.unifi.simpletodoapp.model.Task;
 import it.unifi.simpletodoapp.repository.mongo.TagMongoRepository;
@@ -54,6 +59,13 @@ public class TodoControllerServiceIT {
 	private TagMongoRepository tagMongoRepository;
 	private MongoCollection<Document> taskCollection;
 	private MongoCollection<Document> tagCollection;
+	
+	@BeforeClass
+	public static void setupMongoLogger() {
+		LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+		Logger rootLogger = loggerContext.getLogger("org.mongodb.driver");
+		rootLogger.setLevel(Level.INFO);
+	}
 
 	@Before
 	public void setup() {

--- a/simpletodoapp-gui/src/it/java/it/unifi/simpletodoapp/controller/TodoControllerServiceIT.java
+++ b/simpletodoapp-gui/src/it/java/it/unifi/simpletodoapp/controller/TodoControllerServiceIT.java
@@ -16,10 +16,10 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MongoDBContainer;
 
-import com.mongodb.MongoClient;
-import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
@@ -38,10 +38,9 @@ public class TodoControllerServiceIT {
 	private static final String TASKS_COLLECTION = "tasks";
 	private static final String TAGS_COLLECTION = "tags";
 
-	@SuppressWarnings("rawtypes")
 	@ClassRule
-	public static final GenericContainer mongoContainer =
-	new GenericContainer("krnbr/mongo").withExposedPorts(MONGO_PORT);
+	public static final MongoDBContainer mongoContainer = new MongoDBContainer()
+	.withExposedPorts(MONGO_PORT);
 
 	private TransactionManagerMongo transactionManagerMongo;
 	private TodoService todoService;
@@ -63,10 +62,9 @@ public class TodoControllerServiceIT {
 		 * test */
 		MockitoAnnotations.initMocks(this);
 
-		mongoClient = new MongoClient(new ServerAddress(
-				mongoContainer.getContainerIpAddress(),
-				mongoContainer.getMappedPort(MONGO_PORT))
-				);
+		String mongoRsUrl = mongoContainer.getReplicaSetUrl();
+		mongoClient = MongoClients.create(mongoRsUrl);
+		
 		taskMongoRepository = new TaskMongoRepository(mongoClient, DB_NAME, TASKS_COLLECTION);
 		tagMongoRepository = new TagMongoRepository(mongoClient, DB_NAME, TAGS_COLLECTION);
 

--- a/simpletodoapp-gui/src/it/java/it/unifi/simpletodoapp/view/swing/TodoSwingViewControllerIT.java
+++ b/simpletodoapp-gui/src/it/java/it/unifi/simpletodoapp/view/swing/TodoSwingViewControllerIT.java
@@ -17,11 +17,11 @@ import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MongoDBContainer;
 
-import com.mongodb.MongoClient;
-import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
@@ -40,10 +40,9 @@ public class TodoSwingViewControllerIT extends AssertJSwingJUnitTestCase {
 	private static final String TASKS_COLLECTION = "tasks";
 	private static final String TAGS_COLLECTION = "tags";
 
-	@SuppressWarnings("rawtypes")
 	@ClassRule
-	public static final GenericContainer mongoContainer =
-	new GenericContainer("krnbr/mongo").withExposedPorts(MONGO_PORT);
+	public static final MongoDBContainer mongoContainer = new MongoDBContainer()
+	.withExposedPorts(MONGO_PORT);
 
 	private TodoSwingView todoSwingView;
 	private TodoService todoService;
@@ -68,11 +67,10 @@ public class TodoSwingViewControllerIT extends AssertJSwingJUnitTestCase {
 		 * repositories and collections and the transaction manager; also empties
 		 * the database before each test and creates the application window on
 		 * which tests will be executed */
-		mongoClient = new MongoClient(new ServerAddress(
-				mongoContainer.getContainerIpAddress(),
-				mongoContainer.getMappedPort(MONGO_PORT))
-				);
+		String mongoRsUrl = mongoContainer.getReplicaSetUrl();
+		mongoClient = MongoClients.create(mongoRsUrl);
 		clientSession = mongoClient.startSession();
+		
 		taskMongoRepository = new TaskMongoRepository(mongoClient, DB_NAME, TASKS_COLLECTION);
 		tagMongoRepository = new TagMongoRepository(mongoClient, DB_NAME, TAGS_COLLECTION);
 		transactionManagerMongo = new TransactionManagerMongo(mongoClient, taskMongoRepository, tagMongoRepository);

--- a/simpletodoapp-gui/src/it/java/it/unifi/simpletodoapp/view/swing/TodoSwingViewControllerIT.java
+++ b/simpletodoapp-gui/src/it/java/it/unifi/simpletodoapp/view/swing/TodoSwingViewControllerIT.java
@@ -14,9 +14,11 @@ import org.assertj.swing.junit.runner.GUITestRunner;
 import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
 import org.bson.Document;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.MongoDBContainer;
 
 import com.mongodb.client.MongoClient;
@@ -25,6 +27,9 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 import it.unifi.simpletodoapp.controller.TodoController;
 import it.unifi.simpletodoapp.model.Tag;
 import it.unifi.simpletodoapp.model.Task;
@@ -105,6 +110,13 @@ public class TodoSwingViewControllerIT extends AssertJSwingJUnitTestCase {
 		 * be created anew in the next test */
 		clientSession.close();
 		mongoClient.close();
+	}
+	
+	@BeforeClass
+	public static void setupMongoLogger() {
+		LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+		Logger rootLogger = loggerContext.getLogger("org.mongodb.driver");
+		rootLogger.setLevel(Level.INFO);
 	}
 
 

--- a/simpletodoapp-gui/src/main/java/it/unifi/simpletodoapp/TodoApplication.java
+++ b/simpletodoapp-gui/src/main/java/it/unifi/simpletodoapp/TodoApplication.java
@@ -3,8 +3,8 @@ package it.unifi.simpletodoapp;
 import java.awt.EventQueue;
 import java.util.concurrent.Callable;
 
-import com.mongodb.MongoClient;
-import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 
 import it.unifi.simpletodoapp.controller.TodoController;
 import it.unifi.simpletodoapp.repository.mongo.TagMongoRepository;
@@ -18,11 +18,8 @@ import picocli.CommandLine.Option;
 
 @Command(mixinStandardHelpOptions = true)
 public class TodoApplication implements Callable<Void> {
-	@Option(names = { "--mongo-host" }, description = "MongoDB instance address")
-	private String mongodbHost = "localhost";
-
-	@Option(names = { "--mongo-port" }, description = "MongoDB instance port")
-	private int mongodbPort = 27017;
+	@Option(names = { "--mongo-url" }, description = "MongoDB replica set URL")
+	private String mongoReplicaUrl = "localhost";
 
 	@Option(names = { "--db-name" }, description = "Database name")
 	private String dbName = "todoapp";
@@ -40,8 +37,7 @@ public class TodoApplication implements Callable<Void> {
 	@Override
 	public Void call() throws Exception {
 		EventQueue.invokeLater(() -> {
-			MongoClient mongoClient = 
-					new MongoClient(new ServerAddress(mongodbHost, mongodbPort));
+			MongoClient mongoClient = MongoClients.create(mongoReplicaUrl);
 			TaskMongoRepository taskRepository = 
 					new TaskMongoRepository(mongoClient, dbName, tasksCollection);
 			TagMongoRepository tagRepository =

--- a/simpletodoapp-gui/src/main/resources/logback-test.xml
+++ b/simpletodoapp-gui/src/main/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="com.github.dockerjava" level="INFO"/>
+</configuration>


### PR DESCRIPTION
Switched from a generic testcontainer (knrbr/mongo, which automatically created a replica set) to a MongoDB testcontainer that creates a single node replica set to use ClientSession instances and apply transactions on each database action; also reduced the logging outputs of Testcontainers, Docker and MongoDB Java Driver.