### PR TITLE
Moved logic from controller to service

### DIFF
--- a/simpletodoapp-base/src/main/java/it/unifi/simpletodoapp/repository/TagRepositoryException.java
+++ b/simpletodoapp-base/src/main/java/it/unifi/simpletodoapp/repository/TagRepositoryException.java
@@ -1,0 +1,9 @@
+package it.unifi.simpletodoapp.repository;
+
+public class TagRepositoryException extends RuntimeException{
+	private static final long serialVersionUID = -55404608536003339L;
+
+	public TagRepositoryException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/simpletodoapp-base/src/main/java/it/unifi/simpletodoapp/repository/TaskRepositoryException.java
+++ b/simpletodoapp-base/src/main/java/it/unifi/simpletodoapp/repository/TaskRepositoryException.java
@@ -1,0 +1,9 @@
+package it.unifi.simpletodoapp.repository;
+
+public class TaskRepositoryException extends RuntimeException {
+	private static final long serialVersionUID = 6777400593017780486L;
+
+	public TaskRepositoryException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/simpletodoapp-base/src/main/java/it/unifi/simpletodoapp/repository/mongo/TransactionManagerMongo.java
+++ b/simpletodoapp-base/src/main/java/it/unifi/simpletodoapp/repository/mongo/TransactionManagerMongo.java
@@ -35,7 +35,7 @@ public class TransactionManagerMongo implements TransactionManager {
 		try {
 			// Execute the transaction within the ClientSession
 			value = clientSession.withTransaction(transactionBody);
-		} catch(RuntimeException e) {
+		} catch(MongoException e) {
 			throw new MongoException("Task transaction failed, aborting");
 		} finally {
 			clientSession.close();
@@ -57,7 +57,7 @@ public class TransactionManagerMongo implements TransactionManager {
 		try {
 			// Execute the transaction within the ClientSession
 			value = clientSession.withTransaction(transactionBody);
-		} catch(RuntimeException e) {
+		} catch(MongoException e) {
 			throw new MongoException("Tag transaction failed, aborting");
 		} finally {
 			clientSession.close();
@@ -79,7 +79,7 @@ public class TransactionManagerMongo implements TransactionManager {
 		try {
 			// Execute the transaction within the ClientSession
 			value = clientSession.withTransaction(transactionBody);
-		} catch(RuntimeException e) {
+		} catch(MongoException e) {
 			throw new MongoException("Composite transaction failed, aborting");
 		} finally {
 			clientSession.close();

--- a/simpletodoapp-base/src/main/java/it/unifi/simpletodoapp/service/TodoService.java
+++ b/simpletodoapp-base/src/main/java/it/unifi/simpletodoapp/service/TodoService.java
@@ -75,7 +75,7 @@ public class TodoService {
 						throw new TagRepositoryException("Cannot add tag with duplicated ID " + tag.getId());
 					}
 					
-					List<Tag> tagList = getAllTags();
+					List<Tag> tagList = tagMongoRepository.findAll(clientSession);
 
 					if(tagList.stream().anyMatch(t -> t.getName().equals(tag.getName()))) {
 						throw new TagRepositoryException("Cannot add tag with duplicated name \"" + tag.getName() + "\"");

--- a/simpletodoapp-gui/src/it/java/it/unifi/simpletodoapp/controller/TodoControllerServiceIT.java
+++ b/simpletodoapp-gui/src/it/java/it/unifi/simpletodoapp/controller/TodoControllerServiceIT.java
@@ -183,12 +183,12 @@ public class TodoControllerServiceIT {
 		addTagToCollection(tag, Collections.emptyList());
 
 		// Exercise phase
-		todoController.removeTag(tag);
+		todoController.deleteTag(tag);
 
 		// Verify phase
 		assertThat(getAllTagsFromDatabase())
 		.isEmpty();
-		verify(todoSwingView).tagRemoved(tag);
+		verify(todoSwingView).tagDeleted(tag);
 	}
 
 	@Test

--- a/simpletodoapp-gui/src/it/java/it/unifi/simpletodoapp/view/swing/TodoSwingViewControllerIT.java
+++ b/simpletodoapp-gui/src/it/java/it/unifi/simpletodoapp/view/swing/TodoSwingViewControllerIT.java
@@ -441,7 +441,7 @@ public class TodoSwingViewControllerIT extends AssertJSwingJUnitTestCase {
 
 		// Verify phase
 		assertThat(tagsPanel.label("tagsErrorLabel").text())
-		.isEqualTo("Tag with ID " + tag.getId() + " has already been removed");
+		.isEqualTo("Tag with ID " + tag.getId() + " has already been deleted");
 	}
 
 	@Test @GUITest

--- a/simpletodoapp-gui/src/it/java/it/unifi/simpletodoapp/view/swing/TodoSwingViewControllerIT.java
+++ b/simpletodoapp-gui/src/it/java/it/unifi/simpletodoapp/view/swing/TodoSwingViewControllerIT.java
@@ -214,7 +214,7 @@ public class TodoSwingViewControllerIT extends AssertJSwingJUnitTestCase {
 
 		// Verify phase
 		assertThat(tasksPanel.label("tasksErrorLabel").text())
-		.isEqualTo("Task with ID " + task.getId() + " has already been removed");
+		.isEqualTo("Task with ID " + task.getId() + " has already been deleted");
 	}
 
 	@Test @GUITest

--- a/simpletodoapp-gui/src/main/java/it/unifi/simpletodoapp/controller/TodoController.java
+++ b/simpletodoapp-gui/src/main/java/it/unifi/simpletodoapp/controller/TodoController.java
@@ -27,7 +27,7 @@ public class TodoController {
 		try {
 			todoService.saveTask(task);
 			todoView.taskAdded(task);
-		} catch(TaskRepositoryException exception) {
+		} catch (TaskRepositoryException exception) {
 			todoView.taskError(exception.getMessage());
 		}
 	}
@@ -49,7 +49,7 @@ public class TodoController {
 		try {
 			todoService.saveTag(tag);
 			todoView.tagAdded(tag);
-		} catch(TagRepositoryException exception) {
+		} catch (TagRepositoryException exception) {
 			todoView.tagError(exception.getMessage());
 		}
 
@@ -59,95 +59,60 @@ public class TodoController {
 		try {
 			todoService.deleteTag(tag);
 			todoView.tagDeleted(tag);
-		} catch(TagRepositoryException exception) {
+		} catch (TagRepositoryException exception) {
 			todoView.tagError(exception.getMessage());
 		}
 	}
 
 	public void addTagToTask(Task task, Tag tag) {
-		if (todoService.findTaskById(task.getId()) == null) {
-			todoView.taskError(noTaskErrorMessage(task));
-			return;
-		}
-
-		if (todoService.findTagById(tag.getId()) == null) {
-			todoView.taskError(noTagErrorMessage(tag));
-			return;
-		}
-
-		List<String> currentTags = todoService.findTagsByTaskId(task.getId());
-
-		if (currentTags.stream().anyMatch(t -> t.equals(tag.getId()))) {
-			todoView.taskError("Tag with ID " + tag.getId() + 
-					" is already assigned to task with ID " + task.getId());
-		} else {
+		try {
 			todoService.addTagToTask(task.getId(), tag.getId());
 			todoView.tagAddedToTask(tag);
+		} catch (TaskRepositoryException exception) {
+			todoView.taskError(exception.getMessage());
+		} catch (TagRepositoryException exception) {
+			todoView.tagError(exception.getMessage());
 		}
 	}
 
 	public void removeTagFromTask(Task task, Tag tag) {
-		if (todoService.findTaskById(task.getId()) == null) {
-			todoView.taskError(noTaskErrorMessage(task));
-			return;
-		}
-
-		if (todoService.findTagById(tag.getId()) == null) {
-			todoView.taskError(noTagErrorMessage(tag));
-			return;
-		}
-
-		List<String> currentTags = todoService.findTagsByTaskId(task.getId());
-
-		if (currentTags.stream().anyMatch(t -> t.equals(tag.getId()))) {
+		try {
 			todoService.removeTagFromTask(task.getId(), tag.getId());
 			todoView.tagRemovedFromTask(tag);
-		} else {
-			todoView.taskError("No tag with ID " + tag.getId() + 
-					" assigned to task with ID " + task.getId());
+		} catch (TaskRepositoryException exception) {
+			todoView.taskError(exception.getMessage());
+		} catch (TagRepositoryException exception) {
+			todoView.tagError(exception.getMessage());
 		}
 	}
 
 	public void removeTaskFromTag(Tag tag, Task task) {
-		if (todoService.findTaskById(task.getId()) == null) {
-			todoView.tagError(noTaskErrorMessage(task));
-			return;
-		}
-
-		if (todoService.findTagById(tag.getId()) == null) {
-			todoView.tagError(noTagErrorMessage(tag));
-			return;
-		}
-
-		List<String> currentTasks = todoService.findTasksByTagId(tag.getId());
-
-		if (currentTasks.stream().anyMatch(t -> t.equals(task.getId()))) {
-			todoService.removeTagFromTask(task.getId(), tag.getId());
+		try {
+			todoService.removeTaskFromTag(task.getId(), tag.getId());
 			todoView.taskRemovedFromTag(task);
-		} else {
-			todoView.tagError("No task with ID " + task.getId() +
-					" assigned to tag with ID " + tag.getId());
+		} catch (TaskRepositoryException exception) {
+			todoView.taskError(exception.getMessage());
+		} catch (TagRepositoryException exception) {
+			todoView.tagError(exception.getMessage());
 		}
 	}
 
 	public void getTagsByTask(Task task) {
-		if (todoService.findTaskById(task.getId()) == null) {
-			todoView.taskError(noTaskErrorMessage(task));
-			return;
+		try {
+			List<String> tags = todoService.findTagsByTaskId(task.getId());
+			todoView.showTaskTags(getTags(tags));
+		} catch (TaskRepositoryException exception) {
+			todoView.taskError(exception.getMessage());
 		}
-
-		List<String> tags = todoService.findTagsByTaskId(task.getId());
-		todoView.showTaskTags(getTags(tags));
 	}
 
 	public void getTasksByTag(Tag tag) {
-		if (todoService.findTagById(tag.getId()) == null) {
-			todoView.tagError(noTagErrorMessage(tag));
-			return;
+		try {
+			List<String> tasks = todoService.findTasksByTagId(tag.getId());
+			todoView.showTagTasks(getTasks(tasks));
+		} catch (TagRepositoryException exception) {
+			todoView.tagError(exception.getMessage());
 		}
-
-		List<String> tasks = todoService.findTasksByTagId(tag.getId());
-		todoView.showTagTasks(getTasks(tasks));
 	}
 
 	private List<Tag> getTags(List<String> tagIds) {
@@ -168,13 +133,5 @@ public class TodoController {
 		}
 
 		return tasks;
-	}
-
-	private String noTaskErrorMessage(Task task) {
-		return "No task with ID " + task.getId();
-	}
-
-	private String noTagErrorMessage(Tag tag) {
-		return "No tag with ID " + tag.getId();
 	}
 }

--- a/simpletodoapp-gui/src/main/java/it/unifi/simpletodoapp/controller/TodoController.java
+++ b/simpletodoapp-gui/src/main/java/it/unifi/simpletodoapp/controller/TodoController.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import it.unifi.simpletodoapp.model.Tag;
 import it.unifi.simpletodoapp.model.Task;
+import it.unifi.simpletodoapp.repository.TaskRepositoryException;
 import it.unifi.simpletodoapp.service.TodoService;
 import it.unifi.simpletodoapp.view.TodoView;
 
@@ -22,24 +23,20 @@ public class TodoController {
 	}
 
 	public void addTask(Task task) {
-		Task retrievedTask = todoService.findTaskById(task.getId());
-
-		if (retrievedTask == null) {
+		try {
 			todoService.saveTask(task);
 			todoView.taskAdded(task);
-		} else {
-			todoView.taskError("Cannot add task with duplicated ID " + task.getId());
+		} catch(TaskRepositoryException exception) {
+			todoView.taskError(exception.getMessage());
 		}
 	}
 
 	public void deleteTask(Task task) {
-		Task retrievedTask = todoService.findTaskById(task.getId());
-
-		if (retrievedTask == null) {
-			todoView.taskError("Task with ID " + task.getId() + " has already been removed");
-		} else {
+		try {
 			todoService.deleteTask(task);
 			todoView.taskDeleted(task);
+		} catch (TaskRepositoryException exception) {
+			todoView.taskError(exception.getMessage());
 		}
 	}
 

--- a/simpletodoapp-gui/src/main/java/it/unifi/simpletodoapp/controller/TodoController.java
+++ b/simpletodoapp-gui/src/main/java/it/unifi/simpletodoapp/controller/TodoController.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import it.unifi.simpletodoapp.model.Tag;
 import it.unifi.simpletodoapp.model.Task;
+import it.unifi.simpletodoapp.repository.TagRepositoryException;
 import it.unifi.simpletodoapp.repository.TaskRepositoryException;
 import it.unifi.simpletodoapp.service.TodoService;
 import it.unifi.simpletodoapp.view.TodoView;
@@ -45,30 +46,21 @@ public class TodoController {
 	}
 
 	public void addTag(Tag tag) {
-		Tag retrievedTag = todoService.findTagById(tag.getId());
-
-		if (retrievedTag == null) {
-			List<Tag> tagList = todoService.getAllTags();
-
-			if(tagList.stream().anyMatch(t -> t.getName().equals(tag.getName()))) {
-				todoView.tagError("Cannot add tag with duplicated name \"" + tag.getName() + "\"");
-			} else {
-				todoService.saveTag(tag);
-				todoView.tagAdded(tag);
-			}
-		} else {
-			todoView.tagError("Cannot add tag with duplicated ID " + tag.getId());
+		try {
+			todoService.saveTag(tag);
+			todoView.tagAdded(tag);
+		} catch(TagRepositoryException exception) {
+			todoView.tagError(exception.getMessage());
 		}
+
 	}
 
-	public void removeTag(Tag tag) {
-		Tag retrievedTag = todoService.findTagById(tag.getId());
-
-		if (retrievedTag == null) {
-			todoView.tagError("Tag with ID " + tag.getId() + " has already been removed");
-		} else {
+	public void deleteTag(Tag tag) {
+		try {
 			todoService.deleteTag(tag);
-			todoView.tagRemoved(tag);
+			todoView.tagDeleted(tag);
+		} catch(TagRepositoryException exception) {
+			todoView.tagError(exception.getMessage());
 		}
 	}
 

--- a/simpletodoapp-gui/src/main/java/it/unifi/simpletodoapp/view/TodoView.java
+++ b/simpletodoapp-gui/src/main/java/it/unifi/simpletodoapp/view/TodoView.java
@@ -13,7 +13,7 @@ public interface TodoView {
 	public void showAllTags(List<Tag> allTags);
 	public void tagAdded(Tag tag);
 	public void tagError(String string);
-	public void tagRemoved(Tag tag);
+	public void tagDeleted(Tag tag);
 	public void showTaskTags(List<Tag> tags);
 	public void showTagTasks(List<Task> tasks);
 	public void taskRemovedFromTag(Task task);

--- a/simpletodoapp-gui/src/main/java/it/unifi/simpletodoapp/view/swing/TodoSwingView.java
+++ b/simpletodoapp-gui/src/main/java/it/unifi/simpletodoapp/view/swing/TodoSwingView.java
@@ -235,7 +235,7 @@ public class TodoSwingView extends JFrame implements TodoView {
 	}
 
 	@Override
-	public void tagRemoved(Tag tag) {
+	public void tagDeleted(Tag tag) {
 		tagListModel.removeTag(tag);
 		tagComboModel.removeTag(tag);
 		tagsErrorLabel.setText(" ");
@@ -720,7 +720,7 @@ public class TodoSwingView extends JFrame implements TodoView {
 
 		btnDeleteTag.addActionListener(l -> {
 			Tag tag = tagListModel.get(tagsTagList.getSelectedIndex()).tag;
-			todoController.removeTag(tag);
+			todoController.deleteTag(tag);
 		});
 	}
 

--- a/simpletodoapp-gui/src/test/java/it/unifi/simpletodoapp/controller/TodoControllerTest.java
+++ b/simpletodoapp-gui/src/test/java/it/unifi/simpletodoapp/controller/TodoControllerTest.java
@@ -60,7 +60,7 @@ public class TodoControllerTest {
 	}
 
 	@Test
-	public void testTaskAdditionWithUniqueId() {
+	public void testSuccessfulTaskAddition() {
 		// Setup phase
 		Task task = new Task("1", "Buy groceries");
 		when(todoService.findTaskById(task.getId()))
@@ -77,7 +77,7 @@ public class TodoControllerTest {
 	}
 
 	@Test
-	public void testTaskAdditionWithDuplicatedId() {
+	public void testTaskAdditionException() {
 		// Setup phase
 		Task task = new Task("1", "Buy groceries");
 		doThrow(new TaskRepositoryException("Cannot add task with duplicated ID " + task.getId()))
@@ -114,7 +114,7 @@ public class TodoControllerTest {
 	}
 
 	@Test
-	public void testTaskDeletionWhenTaskAlreadyDeleted() {
+	public void testTaskDeletionException() {
 		// Setup phase
 		Task task = new Task("1", "Buy groceries");
 		doThrow(new TaskRepositoryException("Task with ID " + task.getId() + " has already been deleted"))
@@ -149,7 +149,7 @@ public class TodoControllerTest {
 	}
 
 	@Test
-	public void testTagAdditionWithUniqueIdAndName() {
+	public void testSuccessfulTagAddition() {
 		// Setup phase
 		Tag tag = new Tag("1", "Work");
 		when(todoService.findTagById(tag.getId()))
@@ -166,7 +166,7 @@ public class TodoControllerTest {
 	}
 
 	@Test
-	public void testTagAdditionWithDuplicatedId() {
+	public void testTagAdditionException() {
 		// Setup phase
 		Tag tag = new Tag("1", "Work");
 		doThrow(new TagRepositoryException("Cannot add tag with duplicated ID " + tag.getId()))
@@ -182,46 +182,7 @@ public class TodoControllerTest {
 		inOrder.verify(todoView, never()).tagAdded(any());
 		inOrder.verify(todoView).tagError(
 				"Cannot add tag with duplicated ID " + tag.getId());
-		inOrder.verifyNoMoreInteractions();	}
-
-	@Test
-	public void testTagAdditionWithExistingName() {
-		// Setup phase
-		Tag tag = new Tag("1", "Work");
-		doThrow(new TagRepositoryException("Cannot add tag with duplicated name \"" + tag.getId() + "\""))
-		.when(todoService)
-		.saveTag(tag);
-
-		// Exercise phase
-		todoController.addTag(tag);
-
-		// Verify phase: we also verify the order of the invocations
-		InOrder inOrder = inOrder(todoService, todoView);
-		inOrder.verify(todoService).saveTag(tag);
-		inOrder.verify(todoView, never()).tagAdded(any());
-		inOrder.verify(todoView).tagError(
-				"Cannot add tag with duplicated name \"" + tag.getId() + "\"");
 		inOrder.verifyNoMoreInteractions();
-	}
-
-	@Test
-	public void testTagAdditionWithUniqueIdAndNameWithAlreadyPresentTags() {
-		// Setup phase
-		Tag tag = new Tag("3", "Housekeeping");
-		when(todoService.findTagById(tag.getId()))
-		.thenReturn(null);
-		when(todoService.getAllTags())
-		.thenReturn(Arrays.asList(
-				new Tag("1", "Work"),
-				new Tag("2", "Sport")
-				));
-
-		// Exercise phase
-		todoController.addTag(tag);
-
-		// Verify phase
-		verify(todoService).saveTag(tag);
-		verify(todoView).tagAdded(tag);
 	}
 
 	@Test

--- a/simpletodoapp-gui/src/test/java/it/unifi/simpletodoapp/controller/TodoControllerTest.java
+++ b/simpletodoapp-gui/src/test/java/it/unifi/simpletodoapp/controller/TodoControllerTest.java
@@ -4,13 +4,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -46,25 +42,19 @@ public class TodoControllerTest {
 
 	@Test
 	public void testAllTasksRetrieval() {
-		// Setup phase
-		List<Task> tasks = new ArrayList<>();
-		when(todoService.getAllTasks())
-		.thenReturn(tasks);
-
 		// Exercise phase
 		todoController.getAllTasks();
 
-		// Verify phase
-		verify(todoService).getAllTasks();
-		verify(todoView).showAllTasks(tasks);
+		// Verify phase: we also verify the order of the invocation
+		InOrder inOrder = inOrder(todoService, todoView);
+		inOrder.verify(todoService).getAllTasks();
+		inOrder.verify(todoView).showAllTasks(Collections.emptyList());
 	}
 
 	@Test
 	public void testSuccessfulTaskAddition() {
 		// Setup phase
 		Task task = new Task("1", "Buy groceries");
-		when(todoService.findTaskById(task.getId()))
-		.thenReturn(null);
 
 		// Exercise phase
 		todoController.addTask(task);
@@ -100,8 +90,6 @@ public class TodoControllerTest {
 	public void testSuccessfulTaskDeletion() {
 		// Setup phase
 		Task task = new Task("1", "Buy groceries");
-		when(todoService.findTaskById(task.getId()))
-		.thenReturn(task);
 
 		// Exercise phase
 		todoController.deleteTask(task);
@@ -135,25 +123,19 @@ public class TodoControllerTest {
 
 	@Test
 	public void testAllTagsRetrieval() {
-		// Setup phase
-		List<Tag> tags = new ArrayList<>();
-		when(todoService.getAllTags())
-		.thenReturn(tags);
-
 		// Exercise phase
 		todoController.getAllTags();
 
-		// Verify phase
-		verify(todoService).getAllTags();
-		verify(todoView).showAllTags(tags);
+		// Verify phase: we also verify the order of the invocations
+		InOrder inOrder = inOrder(todoService, todoView);
+		inOrder.verify(todoService).getAllTags();
+		inOrder.verify(todoView).showAllTags(Collections.emptyList());
 	}
 
 	@Test
 	public void testSuccessfulTagAddition() {
 		// Setup phase
 		Tag tag = new Tag("1", "Work");
-		when(todoService.findTagById(tag.getId()))
-		.thenReturn(null);
 
 		// Exercise phase
 		todoController.addTag(tag);
@@ -189,8 +171,6 @@ public class TodoControllerTest {
 	public void testSuccessfulTagDeletion() {
 		// Setup phase
 		Tag tag = new Tag("1", "Work");
-		when(todoService.findTagById(tag.getId()))
-		.thenReturn(tag);
 
 		// Exercise phase
 		todoController.deleteTag(tag);
@@ -202,7 +182,7 @@ public class TodoControllerTest {
 	}
 
 	@Test
-	public void testTagDeletionWhenAlreadyDeleted() {
+	public void testTagDeletionException() {
 		// Setup phase
 		Tag tag = new Tag("1", "Work");
 		doThrow(new TagRepositoryException("Tag with ID " + tag.getId() + " has already been deleted"))
@@ -226,228 +206,170 @@ public class TodoControllerTest {
 		// Setup phase
 		Task task = new Task("1", "Start using TDD");
 		Tag tag = new Tag("1", "Work");
-		when(todoService.findTaskById(task.getId()))
-		.thenReturn(task);
-		when(todoService.findTagById(tag.getId()))
-		.thenReturn(tag);
-
-		// Exercise phase
-		todoController.addTagToTask(task, tag);
-
-		// Verify phase
-		verify(todoService).addTagToTask(task.getId(), tag.getId());
-		verify(todoView).tagAddedToTask(tag);
-	}
-
-	@Test
-	public void testSuccessfulTagAdditionToTaskWithOtherTags() {
-		// Setup phase
-		Task task = new Task("1", "Start using TDD");
-		Tag previousTag = new Tag ("1", "Work");
-		Tag tag = new Tag("2", "Important");
-		when(todoService.findTaskById(task.getId()))
-		.thenReturn(task);
-		when(todoService.findTagById(tag.getId()))
-		.thenReturn(tag);
-		when(todoService.findTagsByTaskId(task.getId()))
-		.thenReturn(Collections.singletonList(previousTag.getId()));
 
 		// Exercise phase
 		todoController.addTagToTask(task, tag);
 
 		// Verify phase: we also verify the order of the invocations
 		InOrder inOrder = inOrder(todoService, todoView);
-		inOrder.verify(todoService).findTagsByTaskId(task.getId());
 		inOrder.verify(todoService).addTagToTask(task.getId(), tag.getId());
 		inOrder.verify(todoView).tagAddedToTask(tag);
-		inOrder.verifyNoMoreInteractions();
 	}
 
 	@Test
-	public void testDuplicatedTagAdditionToTask() {
+	public void testTagAdditionToTaskExceptionTask() {
 		// Setup phase
 		Task task = new Task("1", "Start using TDD");
 		Tag tag = new Tag("1", "Work");
-		when(todoService.findTaskById(task.getId()))
-		.thenReturn(task);
-		when(todoService.findTagById(tag.getId()))
-		.thenReturn(tag);
-		when(todoService.findTagsByTaskId(task.getId()))
-		.thenReturn(Collections.singletonList(tag.getId()));
+		doThrow(new TaskRepositoryException("No task with ID " + task.getId()))
+		.when(todoService)
+		.addTagToTask(task.getId(), tag.getId());
 
 		// Exercise phase
 		todoController.addTagToTask(task, tag);
 
 		// Verify phase: we also verify the order of the invocations
 		InOrder inOrder = inOrder(todoService, todoView);
-		inOrder.verify(todoService).findTagsByTaskId(task.getId());
-		inOrder.verify(todoService, never()).addTagToTask(any(), any());
-		inOrder.verify(todoView, never()).tagAddedToTask(tag);
-		inOrder.verify(todoView).taskError("Tag with ID " + tag.getId() + 
-				" is already assigned to task with ID " + task.getId());
-		inOrder.verifyNoMoreInteractions();
-	}
-
-	@Test
-	public void testTagAdditionToTaskWhenTaskNonExistent() {
-		// Setup phase
-		Task task = new Task("1", "Start using TDD");
-		Tag tag = new Tag("1", "Work");
-		when(todoService.findTaskById(task.getId()))
-		.thenReturn(null);
-
-		// Exercise phase
-		todoController.addTagToTask(task, tag);
-
-		// Verify phase: we also verify the order of the invocations
-		InOrder inOrder = inOrder(todoService, todoView);
-		inOrder.verify(todoService).findTaskById(task.getId());
-		inOrder.verify(todoService, never()).addTagToTask(any(), any());
-		inOrder.verify(todoView, never()).tagAddedToTask(tag);
+		inOrder.verify(todoService).addTagToTask(task.getId(), tag.getId());
+		inOrder.verify(todoView, never()).tagAddedToTask(any());
 		inOrder.verify(todoView).taskError("No task with ID " + task.getId());
 		inOrder.verifyNoMoreInteractions();
 	}
 
 	@Test
-	public void testTagAdditionToTaskWhenTagNonExistent() {
+	public void testTagAdditionToTaskExceptionTag() {
 		// Setup phase
 		Task task = new Task("1", "Start using TDD");
 		Tag tag = new Tag("1", "Work");
-		when(todoService.findTaskById(task.getId()))
-		.thenReturn(task);
-		when(todoService.findTagById(tag.getId()))
-		.thenReturn(null);
+		doThrow(new TagRepositoryException("No tag with ID " + tag.getId()))
+		.when(todoService)
+		.addTagToTask(task.getId(), tag.getId());
 
 		// Exercise phase
 		todoController.addTagToTask(task, tag);
 
 		// Verify phase: we also verify the order of the invocations
 		InOrder inOrder = inOrder(todoService, todoView);
-		inOrder.verify(todoService).findTagById(tag.getId());
-		inOrder.verify(todoService, never()).addTagToTask(any(), any());
-		inOrder.verify(todoView).taskError("No tag with ID " + tag.getId());
-		inOrder.verifyNoMoreInteractions();	
+		inOrder.verify(todoService).addTagToTask(task.getId(), tag.getId());
+		inOrder.verify(todoView, never()).tagAddedToTask(any());
+		inOrder.verify(todoView).tagError("No tag with ID " + tag.getId());
+		inOrder.verifyNoMoreInteractions();
 	}
 
 	@Test
-	public void testTagRemovalFromTask() {
+	public void testSuccessfulTagRemovalFromTask() {
 		// Setup phase
 		Task task = new Task("1", "Start using TDD");
 		Tag tag = new Tag("1", "Work");
-		when(todoService.findTaskById(task.getId()))
-		.thenReturn(task);
-		when(todoService.findTagById(tag.getId()))
-		.thenReturn(tag);
-		when(todoService.findTagsByTaskId(task.getId()))
-		.thenReturn(Collections.singletonList(tag.getId()));
-
-		// Exercise phase
-		todoController.removeTagFromTask(task, tag);
-
-		// Verify phase
-		verify(todoService).removeTagFromTask(task.getId(), tag.getId());
-		verify(todoView).tagRemovedFromTask(tag);
-	}
-
-	@Test
-	public void testTagRemovalFromTaskWithOtherTags() {
-		// Setup phase
-		Task task = new Task("1", "Start using TDD");
-		Tag previousTag = new Tag("1", "Work");
-		Tag tag = new Tag("2", "Important");
-		List<String> previousTags = Arrays.asList(previousTag.getId(), tag.getId());
-		when(todoService.findTaskById(task.getId()))
-		.thenReturn(task);
-		when(todoService.findTagById(tag.getId()))
-		.thenReturn(tag);
-		when(todoService.findTagsByTaskId(task.getId()))
-		.thenReturn(previousTags);
 
 		// Exercise phase
 		todoController.removeTagFromTask(task, tag);
 
 		// Verify phase: we also verify the order of the invocations
 		InOrder inOrder = inOrder(todoService, todoView);
-		inOrder.verify(todoService).findTagsByTaskId(task.getId());
 		inOrder.verify(todoService).removeTagFromTask(task.getId(), tag.getId());
 		inOrder.verify(todoView).tagRemovedFromTask(tag);
-		inOrder.verifyNoMoreInteractions();
 	}
 
 	@Test
-	public void testTagRemovalFromTaskWhenTagNotAssignedToTask() {
-		// Setup phase
-		Task task = new Task("1", "Start using TDD");
-		Tag previousTag = new Tag("1", "Work");
-		Tag tag = new Tag("2", "Important");
-		when(todoService.findTaskById(task.getId()))
-		.thenReturn(task);
-		when(todoService.findTagById(tag.getId()))
-		.thenReturn(tag);
-		when(todoService.findTagsByTaskId(task.getId()))
-		.thenReturn(Collections.singletonList(previousTag.getId()));
-
-		// Exercise phase
-		todoController.removeTagFromTask(task, tag);
-
-		// Verify phase: we also verify the order of the invocations
-		InOrder inOrder = inOrder(todoService, todoView);
-		inOrder.verify(todoService).findTagsByTaskId(task.getId());
-		inOrder.verify(todoService, never()).removeTagFromTask(any(), any());
-		inOrder.verify(todoView, never()).tagRemovedFromTask(tag);
-		inOrder.verify(todoView).taskError("No tag with ID " + tag.getId() +
-				" assigned to task with ID " + task.getId());
-		inOrder.verifyNoMoreInteractions();
-	}
-
-	@Test
-	public void testTagRemovalFromTaskWhenTaskNonExistent() {
+	public void testTagRemovalFromTaskExceptionTask() {
 		// Setup phase
 		Task task = new Task("1", "Start using TDD");
 		Tag tag = new Tag("1", "Work");
-		when(todoService.findTaskById(task.getId()))
-		.thenReturn(null);
+		doThrow(new TaskRepositoryException("No task with ID " + task.getId()))
+		.when(todoService)
+		.removeTagFromTask(task.getId(), tag.getId());
 
 		// Exercise phase
 		todoController.removeTagFromTask(task, tag);
 
 		// Verify phase: we also verify the order of the invocations
 		InOrder inOrder = inOrder(todoService, todoView);
-		inOrder.verify(todoService).findTaskById(task.getId());
-		inOrder.verify(todoService, never()).removeTagFromTask(any(), any());
-		inOrder.verify(todoView, never()).tagRemovedFromTask(tag);
+		inOrder.verify(todoService).removeTagFromTask(task.getId(), tag.getId());
+		inOrder.verify(todoView, never()).tagRemovedFromTask(any());
 		inOrder.verify(todoView).taskError("No task with ID " + task.getId());
 		inOrder.verifyNoMoreInteractions();
 	}
-
+	
 	@Test
-	public void testTagRemovalFromTaskWhenTagNonExistent() {
+	public void testTagRemovalFromTaskExceptionTag() {
 		// Setup phase
 		Task task = new Task("1", "Start using TDD");
 		Tag tag = new Tag("1", "Work");
-		when(todoService.findTaskById(task.getId()))
-		.thenReturn(task);
-		when(todoService.findTagById(tag.getId()))
-		.thenReturn(null);
+		doThrow(new TagRepositoryException("No tag with ID " + tag.getId()))
+		.when(todoService)
+		.removeTagFromTask(task.getId(), tag.getId());
 
 		// Exercise phase
 		todoController.removeTagFromTask(task, tag);
 
 		// Verify phase: we also verify the order of the invocations
 		InOrder inOrder = inOrder(todoService, todoView);
-		inOrder.verify(todoService).findTagById(tag.getId());
-		inOrder.verify(todoService, never()).removeTagFromTask(any(), any());
-		inOrder.verify(todoView, never()).tagRemovedFromTask(tag);
-		inOrder.verify(todoView).taskError("No tag with ID " + tag.getId());
+		inOrder.verify(todoService).removeTagFromTask(task.getId(), tag.getId());
+		inOrder.verify(todoView, never()).tagRemovedFromTask(any());
+		inOrder.verify(todoView).tagError("No tag with ID " + tag.getId());
 		inOrder.verifyNoMoreInteractions();
 	}
+	
+	@Test
+	public void testSuccessfulTaskRemovalFromTag() {
+		// Setup phase
+		Task task = new Task("1", "Start using TDD");
+		Tag tag = new Tag("1", "Work");
 
+		// Exercise phase
+		todoController.removeTaskFromTag(tag, task);
+
+		// Verify phase: we also verify the order of the invocations
+		InOrder inOrder = inOrder(todoService, todoView);
+		inOrder.verify(todoService).removeTaskFromTag(tag.getId(), task.getId());
+		inOrder.verify(todoView).taskRemovedFromTag(task);
+	}
+
+	@Test
+	public void testTaskRemovalFromTagExceptionTask() {
+		// Setup phase
+		Task task = new Task("1", "Start using TDD");
+		Tag tag = new Tag("1", "Work");
+		doThrow(new TaskRepositoryException("No task with ID " + task.getId()))
+		.when(todoService)
+		.removeTaskFromTag(tag.getId(), task.getId());
+
+		// Exercise phase
+		todoController.removeTaskFromTag(tag, task);
+
+		// Verify phase: we also verify the order of the invocations
+		InOrder inOrder = inOrder(todoService, todoView);
+		inOrder.verify(todoService).removeTaskFromTag(tag.getId(), task.getId());
+		inOrder.verify(todoView, never()).taskRemovedFromTag(any());
+		inOrder.verify(todoView).taskError("No task with ID " + task.getId());
+		inOrder.verifyNoMoreInteractions();
+	}
+	
+	@Test
+	public void testTaskRemovalFromTagExceptionTag() {
+		// Setup phase
+		Task task = new Task("1", "Start using TDD");
+		Tag tag = new Tag("1", "Work");
+		doThrow(new TagRepositoryException("No tag with ID " + tag.getId()))
+		.when(todoService)
+		.removeTaskFromTag(tag.getId(), task.getId());
+
+		// Exercise phase
+		todoController.removeTaskFromTag(tag, task);
+
+		// Verify phase: we also verify the order of the invocations
+		InOrder inOrder = inOrder(todoService, todoView);
+		inOrder.verify(todoService).removeTaskFromTag(tag.getId(), task.getId());
+		inOrder.verify(todoView, never()).tagRemovedFromTask(any());
+		inOrder.verify(todoView).tagError("No tag with ID " + tag.getId());
+		inOrder.verifyNoMoreInteractions();
+	}
+	
 	@Test
 	public void testRetrieveTagsAssociatedToTask() {
 		// Setup phase
 		Task task = new Task("1", "Start using TDD");
-		when(todoService.findTaskById(task.getId()))
-		.thenReturn(task);
 		when(todoService.findTagsByTaskId(task.getId()))
 		.thenReturn(Collections.singletonList("1"));
 		when(todoService.findTagById("1"))
@@ -457,34 +379,35 @@ public class TodoControllerTest {
 		todoController.getTagsByTask(task);
 
 		// Verify phase
-		verify(todoService).findTagsByTaskId(task.getId());
-		verify(todoView).showTaskTags(Collections.singletonList(new Tag("1", "Work")));
+		InOrder inOrder = inOrder(todoService, todoView);
+		inOrder.verify(todoService).findTagsByTaskId(task.getId());
+		inOrder.verify(todoView).showTaskTags(Collections.singletonList(new Tag("1", "Work")));
+		inOrder.verifyNoMoreInteractions();
 	}
-
+	
 	@Test
-	public void testRetrieveTagsAssociatedToNonExistentTask() {
+	public void testRetrieveTagsAssociatedToTaskException() {
 		// Setup phase
 		Task task = new Task("1", "Start using TDD");
-		when(todoService.findTaskById(task.getId()))
-		.thenReturn(null);
+		doThrow(new TaskRepositoryException("No task with ID " + task.getId()))
+		.when(todoService)
+		.findTagsByTaskId(task.getId());
 
 		// Exercise phase
 		todoController.getTagsByTask(task);
 
-		// Verify phase: we also verify the order of the invocations
+		// Verify phase
 		InOrder inOrder = inOrder(todoService, todoView);
-		inOrder.verify(todoService).findTaskById(task.getId());
+		inOrder.verify(todoService).findTagsByTaskId(task.getId());
 		inOrder.verify(todoView, never()).showTaskTags(any());
 		inOrder.verify(todoView).taskError("No task with ID " + task.getId());
 		inOrder.verifyNoMoreInteractions();
 	}
-
+	
 	@Test
 	public void testRetrieveTasksAssociatedToTag() {
 		// Setup phase
 		Tag tag = new Tag("1", "Work");
-		when(todoService.findTagById(tag.getId()))
-		.thenReturn(tag);
 		when(todoService.findTasksByTagId(tag.getId()))
 		.thenReturn(Collections.singletonList("1"));
 		when(todoService.findTaskById("1"))
@@ -493,142 +416,31 @@ public class TodoControllerTest {
 		// Exercise phase
 		todoController.getTasksByTag(tag);
 
-		// Verify
-		verify(todoService).findTasksByTagId(tag.getId());
-		verify(todoView).showTagTasks(
-				Collections.singletonList(new Task("1", "Start using TDD")));
+		// Verify phase
+		InOrder inOrder = inOrder(todoService, todoView);
+		inOrder.verify(todoService).findTasksByTagId(tag.getId());
+		inOrder.verify(todoView).showTagTasks(
+				Collections.singletonList(new Task("1", "Start using TDD"))
+				);
+		inOrder.verifyNoMoreInteractions();
 	}
-
+	
 	@Test
-	public void testRetrieveTasksAssociatedToNonExistentTag() {
+	public void testRetrieveTasksAssociatedToTagException() {
+		// Setup phase
 		Tag tag = new Tag("1", "Work");
-		when(todoService.findTagById(tag.getId()))
-		.thenReturn(null);
+		doThrow(new TagRepositoryException("No tag with ID " + tag.getId()))
+		.when(todoService)
+		.findTasksByTagId(tag.getId());
 
 		// Exercise phase
 		todoController.getTasksByTag(tag);
 
-		// Verify: we also verify the order of the invocations
+		// Verify phase
 		InOrder inOrder = inOrder(todoService, todoView);
-		inOrder.verify(todoService).findTagById(tag.getId());
+		inOrder.verify(todoService).findTasksByTagId(tag.getId());
 		inOrder.verify(todoView, never()).showTagTasks(any());
 		inOrder.verify(todoView).tagError("No tag with ID " + tag.getId());
-		inOrder.verifyNoMoreInteractions();
-	}
-
-	@Test
-	public void testTaskRemovalFromTag() {
-		// Setup phase
-		Task task = new Task("1", "Start using TDD");
-		Tag tag = new Tag("1", "Work");
-		when(todoService.findTaskById(task.getId()))
-		.thenReturn(task);
-		when(todoService.findTagById(tag.getId()))
-		.thenReturn(tag);
-		when(todoService.findTasksByTagId(tag.getId()))
-		.thenReturn(Collections.singletonList(task.getId()));
-
-		// Exercise phase
-		todoController.removeTaskFromTag(tag, task);
-
-		// Verify phase
-		verify(todoService).removeTagFromTask(task.getId(), tag.getId());
-		verify(todoView).taskRemovedFromTag(task);
-	}
-
-	@Test
-	public void testTaskRemovalFromTagWithOtherTasks() {
-		// Setup phase
-		Task previousTask = new Task("1", "Start using TDD");
-		Task task = new Task("2", "Study a lot");
-		Tag tag = new Tag("1", "Work");
-		List<String> previousTasks = Arrays.asList(previousTask.getId(), task.getId());
-		when(todoService.findTaskById(task.getId()))
-		.thenReturn(task);
-		when(todoService.findTagById(tag.getId()))
-		.thenReturn(tag);
-		when(todoService.findTasksByTagId(tag.getId()))
-		.thenReturn(previousTasks);
-
-		// Exercise phase
-		todoController.removeTaskFromTag(tag, task);
-
-		// Verify phase: we also verify the order of the invocations
-		InOrder inOrder = inOrder(todoService, todoView);
-		inOrder.verify(todoService).findTasksByTagId(tag.getId());
-		inOrder.verify(todoService).removeTagFromTask(task.getId(), tag.getId());
-		inOrder.verify(todoView).taskRemovedFromTag(task);
-		inOrder.verifyNoMoreInteractions();
-	}
-
-	@Test
-	public void testTaskRemovalFromTagWhenTaskNotAssignedToTag() {
-		// Setup phase
-		Task previousTask = new Task("1", "Start using TDD");
-		Task task = new Task("2", "Study a lot");
-		Tag tag = new Tag("1", "Work");
-		when(todoService.findTaskById(task.getId()))
-		.thenReturn(task);
-		when(todoService.findTagById(tag.getId()))
-		.thenReturn(tag);
-		when(todoService.findTasksByTagId(tag.getId()))
-		.thenReturn(Collections.singletonList(previousTask.getId()));
-
-		// Exercise phase
-		todoController.removeTaskFromTag(tag, task);
-
-		// Verify phase: we also verify the order of the invocations
-		InOrder inOrder = inOrder(todoService, todoView);
-		inOrder.verify(todoService).findTasksByTagId(tag.getId());
-		inOrder.verify(todoService, never()).removeTagFromTask(any(), any());
-		inOrder.verify(todoView, never()).taskRemovedFromTag(task);
-		inOrder.verify(todoView).tagError("No task with ID " + task.getId() +
-				" assigned to tag with ID " + tag.getId());
-		inOrder.verifyNoMoreInteractions();
-	}
-
-	@Test
-	public void testTaskRemovalFromTagWhenTagNonExistent() {
-		// Setup phase
-		Task task = new Task("1", "Start using TDD");
-		Tag tag = new Tag("1", "Work");
-		when(todoService.findTaskById(task.getId()))
-		.thenReturn(task);
-		when(todoService.findTagById(tag.getId()))
-		.thenReturn(null);
-
-		// Exercise phase
-		todoController.removeTaskFromTag(tag, task);
-
-		// Verify phase: we also verify the order of the invocations
-		InOrder inOrder = inOrder(todoService, todoView);
-		inOrder.verify(todoService).findTaskById(task.getId());
-		inOrder.verify(todoService).findTagById(tag.getId());
-		inOrder.verify(todoService, never()).removeTagFromTask(any(), any());
-		inOrder.verify(todoView, never()).taskRemovedFromTag(task);
-		inOrder.verify(todoView).tagError("No tag with ID " + tag.getId());
-		inOrder.verifyNoMoreInteractions();
-	}
-
-	@Test
-	public void testTaskRemovalFromTagWhenTaskNonExistent() {
-		// Setup phase
-		Task task = new Task("1", "Start using TDD");
-		Tag tag = new Tag("1", "Work");
-		when(todoService.findTagById(tag.getId()))
-		.thenReturn(tag);
-		when(todoService.findTaskById(task.getId()))
-		.thenReturn(null);
-
-		// Exercise phase
-		todoController.removeTaskFromTag(tag, task);
-
-		// Verify phase: we also verify the order of the invocations
-		InOrder inOrder = inOrder(todoService, todoView);
-		inOrder.verify(todoService).findTaskById(task.getId());
-		inOrder.verify(todoService, never()).removeTagFromTask(any(), any());
-		inOrder.verify(todoView, never()).taskRemovedFromTag(task);
-		inOrder.verify(todoView).tagError("No task with ID " + task.getId());
 		inOrder.verifyNoMoreInteractions();
 	}
 }

--- a/simpletodoapp-gui/src/test/java/it/unifi/simpletodoapp/view/swing/TodoSwingViewTest.java
+++ b/simpletodoapp-gui/src/test/java/it/unifi/simpletodoapp/view/swing/TodoSwingViewTest.java
@@ -706,7 +706,7 @@ public class TodoSwingViewTest extends AssertJSwingJUnitTestCase {
 		tagsPanel.button("btnDeleteTag").click();
 
 		// Verify phase
-		verify(todoController).removeTag(tag);
+		verify(todoController).deleteTag(tag);
 	}
 
 	@Test @GUITest
@@ -720,7 +720,7 @@ public class TodoSwingViewTest extends AssertJSwingJUnitTestCase {
 		GuiActionRunner.execute(
 				() -> {
 					todoSwingView.tagAdded(tag);
-					todoSwingView.tagRemoved(tag);
+					todoSwingView.tagDeleted(tag);
 				});
 
 		// Verify phase
@@ -740,7 +740,7 @@ public class TodoSwingViewTest extends AssertJSwingJUnitTestCase {
 				() -> {
 					todoSwingView.tagAdded(tag);
 					todoSwingView.tagError("This is an error message");
-					todoSwingView.tagRemoved(tag);
+					todoSwingView.tagDeleted(tag);
 				});
 
 		// Verify phase


### PR DESCRIPTION
Moved database checks for duplicated and/or inexistent tasks and tags from `TodoController` to `TodoService`, adding exception handling in the controller to handle errors during service operations: these checks were meant as service's responsibilities from the start and were erroneously attributed to the controller.